### PR TITLE
add websocket-client deps to requirements.txt

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,3 +4,4 @@ docker
 python-multipart
 pydantic
 execnet
+websocket-client


### PR DESCRIPTION
I encountered below errors when `docker-compose up` for the python server.

> ModuleNotFoundError: No module named 'websocket'

```sh
$ docker-compose -f docker_dev.yml up              
[+] Building 0.0s (0/0)                                           docker:desktop-linux
[+] Running 2/2
 ✔ Network app_network_for_codebox     Creat...                                   0.0s 
 ✔ Container app-codebox_server_dev-1  Cr...                                      0.0s 
Attaching to app-codebox_server_dev-1
app-codebox_server_dev-1  | INFO:     Will watch for changes in these directories: ['/app']
app-codebox_server_dev-1  | INFO:     Uvicorn running on http://0.0.0.0:5002 (Press CTRL+C to quit)
app-codebox_server_dev-1  | INFO:     Started reloader process [1] using StatReload
app-codebox_server_dev-1  | Process SpawnProcess-1:
app-codebox_server_dev-1  | Traceback (most recent call last):
app-codebox_server_dev-1  |   File "/usr/local/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
app-codebox_server_dev-1  |     self.run()

...

app-codebox_server_dev-1  |   File "/app/main.py", line 11, in <module>
app-codebox_server_dev-1  |     from codebox_session import global_codebox_session_manager
app-codebox_server_dev-1  |   File "/app/codebox_session.py", line 19, in <module>
app-codebox_server_dev-1  |     from jupyter_api import JupyterAPI
app-codebox_server_dev-1  |   File "/app/jupyter_api.py", line 5, in <module>
app-codebox_server_dev-1  |     from websocket import create_connection
app-codebox_server_dev-1  | ModuleNotFoundError: No module named 'websocket'
```